### PR TITLE
Update bmp280.py

### DIFF
--- a/bmp280.py
+++ b/bmp280.py
@@ -119,7 +119,8 @@ class BMP280:
         self._new_read_ms = 200  # interval between
         self._last_read_ts = 0
 
-        self.use_case(use_case)
+         if use_case is not None:
+            self.use_case(use_case)self.use_case(use_case)
 
     def _read(self, addr, size=1):
         return self._bmp_i2c.readfrom_mem(self._i2c_addr, addr, size)

--- a/bmp280.py
+++ b/bmp280.py
@@ -119,8 +119,7 @@ class BMP280:
         self._new_read_ms = 200  # interval between
         self._last_read_ts = 0
 
-        if use_case is None:
-            self.use_case(use_case)
+        self.use_case(use_case)
 
     def _read(self, addr, size=1):
         return self._bmp_i2c.readfrom_mem(self._i2c_addr, addr, size)


### PR DESCRIPTION
Removed condition generally preventing method use_case being called at the end of initialisation. Previously the sensor did not start collecting readings until an explicit call to use_case was made post-initialisation. This doesn't seem like the design intent.