### PR TITLE
Ensure calibration registers loaded before read

### DIFF
--- a/bmp280.py
+++ b/bmp280.py
@@ -90,6 +90,8 @@ class BMP280:
         self._bmp_i2c = i2c_bus
         self._i2c_addr = addr
 
+        while self.is_updating:
+            pass
         # read calibration data
         # < little-endian
         # H unsigned short


### PR DESCRIPTION
The calibration registers are read immediately on initialization of a BMP280 instance, however if the device itself has not completed power-on-reset these registers may not contain valid data. We should wait until the `im_update` bit from the `status` register is off before continuing (see section 4.3.3 of [bst-bmp280-ds001.pdf](https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bmp280-ds001.pdf) for details).

I've tested the changes by forcing a reset (section 4.3.2) immediately before initializing BMP280 and found it takes between 1 and 3 passes through the loop before the update is complete. The following code was used in testing:
```py
i2c = I2C(0, scl=Pin(1), sda=Pin(0))
# issue a reset directly to the bmp280 
i2c.writeto_mem(0x76, 0xE0, bytearray([0xB6]))
bmp = BMP280(i2c)
```