### PR TITLE
Properly handle use_case in constructor

### DIFF
--- a/bmp280.py
+++ b/bmp280.py
@@ -119,7 +119,7 @@ class BMP280:
         self._new_read_ms = 200  # interval between
         self._last_read_ts = 0
 
-        if use_case is None:
+        if use_case is not None:
             self.use_case(use_case)
 
     def _read(self, addr, size=1):


### PR DESCRIPTION
I couldn't get this working in `BMP280_CASE_WEATHER` mode, looking at the code it seems we're not really setting `use_case` on `__init__`.